### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-report-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-report-bug.yml
@@ -1,0 +1,44 @@
+name: '🐛 Bug report'
+labels: 'bug'
+description: Create a bug report to help us improve
+
+body:
+  - type: textarea
+    attributes:
+      label: Expected and Results
+      description: What was your expected result?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Related environent and versions
+      description: |
+        If any version of Gradle Build Tool, Gradle plugin, platform or OS may be related to the issue,
+        please list them here. 
+    validations:
+      required: false
+  
+  - type: textarea
+    attributes:
+      label: Reproduction steps
+      description: |
+        Write bullet-point reproduction steps, especially if the issue is not trivial to reproduce.
+      placeholder: |
+        1. Step 1: ...
+        2. Step 2: ...
+    validations:
+      required: false
+  
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        You can provide additional context below.
+        If you would like to contribute a fix, let us know.
+
+  - type: markdown
+    attributes:
+      value: |
+        **Never report security issues on GitHub or other public channels**
+        Follow these instruction to report security issues: https://gradleup.com/org/SECURITY/

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,21 @@
+name: '🚀 Feature request'
+labels: 'enhancement'
+description: I have a suggestion
+
+body:
+  - type: textarea
+    attributes:
+      label: What feature do you want to see added?
+      description: A clear and concise description of your feature request.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Upstream changes
+      description: Link here any upstream changes that might be relevant to this request
+
+  - type: textarea
+    attributes:
+      label: Are you interested in contributing this feature?
+      description: Indicate if this is something you would like to work on, and how we can best support you in doing so. More details [on contributing](https://github.com/jenkinsci/.github/blob/master/CONTRIBUTING.md)

--- a/.github/ISSUE_TEMPLATE/3-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/3-documentation.yml
@@ -1,0 +1,20 @@
+name: '📝 Documentation'
+labels: 'documentation'
+description: 'Let us know if any documentation is missing or could be improved'
+
+body:
+  - type: textarea
+    attributes:
+      label: Describe your use-case which is not covered by existing documentation.
+      description: If it is easier to submit a documentation patch instead of writing an issue, just do it!
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Reference any relevant documentation, other materials or issues/pull requests that can be used for inspiration.
+
+  - type: textarea
+    attributes:
+      label: Are you interested in contributing to the documentation?
+      description: Indicate if this is something you would like to work on, and how we can best support you in doing so. More details [on contributing](https://github.com/jenkinsci/.github/blob/master/CONTRIBUTING.md)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "🛟 Community Slack"
+    url: https://gradleup.com/docs/community/participate/#slack
+    about: >
+      For community discussions, consider joining our the #gradleup channel the Gradle Community Slack.
+


### PR DESCRIPTION
Largely inspired by https://github.com/jenkinsci/.github/tree/master/.github/ISSUE_TEMPLATE