### PR TITLE
Issue templates: add an "other" free-form option

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-other.yml
+++ b/.github/ISSUE_TEMPLATE/4-other.yml
@@ -1,0 +1,11 @@
+name: Other
+description: Free form issue for everything that doesn't fit in the templates above
+body:
+  - type: textarea
+    attributes:
+      label: Description
+      value: |
+        This is a place of freedom. Enjoy!
+    validations:
+      required: true
+


### PR DESCRIPTION
Sometimes I just want to enter something quickly and the other templates can be a bit verbose.